### PR TITLE
feat: add basic AWS SSM command to install and configure Lacework agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+# IDE files
+.idea
+
 # Local .terraform directories
 **/.terraform/*
+
+# Terraform lock file
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -1,0 +1,3 @@
+# Default AWS SSM command deployment
+
+This example deploys into AWS an AWS SSM Command that can be used to install the Lacework agent on a Linux EC2 instance.

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "dev_ops"
+}
+
+module "lacework_aws_ssm_agents_install" {
+  source = "../../"
+
+  lacework_access_token = "your-token-here"
+
+  lacework_agent_tags = {
+    env = "dev"
+  }
+
+  aws_resources_tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "us-east-1"
-  profile = "dev_ops"
 }
 
 module "lacework_aws_ssm_agents_install" {

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -6,8 +6,6 @@ provider "aws" {
 module "lacework_aws_ssm_agents_install" {
   source = "../../"
 
-  lacework_access_token = "your-token-here"
-
   lacework_agent_tags = {
     env = "dev"
   }
@@ -16,4 +14,49 @@ module "lacework_aws_ssm_agents_install" {
     billing = "testing"
     owner   = "myself"
   }
+}
+
+resource "aws_resourcegroups_group" "testing" {
+  name = "Testing"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = [
+        "AWS::EC2::Instance"
+      ]
+
+      TagFilters = [
+        {
+          Key = "environment"
+          Values = [
+            "Testing"
+          ]
+        }
+      ]
+    })
+  }
+
+  tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}
+
+resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
+  association_name = "install-lacework-agents-testing-group"
+
+  name = module.lacework_aws_ssm_agents_install.ssm_document_name
+
+  targets {
+    key = "resource-groups:Name"
+    values = [
+      aws_resourcegroups_group.testing.name,
+    ]
+  }
+
+  parameters = {
+    Token = "my-lacework-token"
+  }
+
+  compliance_severity = "HIGH"
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 module "lacework_aws_ssm_agents_install" {

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.0"
+}

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,8 @@ resource "aws_ssm_document" "setup_lacework_agent" {
 
       Token = {
         type        = "String"
-        description = "The Lacework agent token"
+        description = "The access token for the Lacework agent"
+        default     = var.lacework_access_token
       }
 
       # TODO: Figure out the proper way of passing tags to our bash script, currently does not generate a valid config.json file

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,53 @@
+resource "aws_ssm_document" "setup_lacework_agent" {
+  name          = "${var.aws_resources_prefix}setup-lacework-agent"
+  document_type = "Command"
+
+  target_type = "/AWS::EC2::Instance"
+
+  content = jsonencode({
+    schemaVersion = "2.2"
+    description   = "Setup the Lacework agent on a Linux instance"
+
+    parameters = {
+      LaceworkInstallPath = {
+        type        = "String"
+        description = "The expected Lacework installation path"
+        default     = "/var/lib/lacework"
+      }
+
+      Token = {
+        type        = "String"
+        description = "The Lacework agent token"
+      }
+
+      # TODO: Figure out the proper way of passing tags to our bash script, currently does not generate a valid config.json file
+      Tags = {
+        type        = "String"
+        description = "The Lacework agent token"
+        default     = jsonencode(var.lacework_agent_tags)
+      }
+    }
+
+    mainSteps = [
+      {
+        action = "aws:runShellScript"
+        name   = "SetupLaceworkAgent"
+
+        precondition = {
+          StringEquals = [
+            "platformType",
+            "Linux",
+          ]
+        }
+
+        inputs = {
+          runCommand = [
+            file("${path.module}/setup_lacework_agent.sh"),
+          ]
+        }
+      }
+    ]
+  })
+
+  tags = var.aws_resources_tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "ssm_document_name" {
+  description = "Name of the AWS SSM Document that setups the Lacework agent"
+  value       = aws_ssm_document.setup_lacework_agent.name
+}

--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -5,9 +5,8 @@ set -e
 LACEWORK_INSTALL_PATH="{{ LaceworkInstallPath }}"
 
 # TODO: Fetch the token from AWS SSM Parameter Store instead of taking it in as a Command parameter (avoid leaks in the AWS Console)
-TOKEN="{{ Token }}"
-TAGS="{{ Tags }}"
-
+TOKEN='{{ Token }}'
+TAGS='{{ Tags }}'
 
 # TODO: Handle systems that don't have systemctl
 if systemctl is-active --quiet kubelet; then
@@ -19,7 +18,7 @@ if [ ! -d "$LACEWORK_INSTALL_PATH" ]; then
   echo "Lacework agent not installed, installing..."
 
   # TODO: Add the support for hosts that don't have curl installed
-  curl https://packages.lacework.net/install.sh > /tmp/install.sh
+  curl https://packages.lacework.net/install.sh >/tmp/install.sh
 
   chmod +x /tmp/install.sh
 
@@ -27,11 +26,11 @@ if [ ! -d "$LACEWORK_INSTALL_PATH" ]; then
   sudo /tmp/install.sh "$TOKEN"
 
   rm /tmp/install.sh
-else
-  echo "Lacework is already installed, configuring the agent token..."
+fi
 
-  # TODO: Add the support for other Lacework configuration options
-  cat > "$LACEWORK_INSTALL_PATH/config/config.json" <<EOF
+# TODO: Add the support for other Lacework configuration options
+echo "Updating the Lacework agent config.json file..."
+cat >"$LACEWORK_INSTALL_PATH/config/config.json" <<EOF
 {
   "tokens": {
     "AccessToken": "$TOKEN"
@@ -39,6 +38,5 @@ else
   "tags": $TAGS
 }
 EOF
-fi
 
 echo "Lacework configured successfully!"

--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+LACEWORK_INSTALL_PATH="{{ LaceworkInstallPath }}"
+
+# TODO: Fetch the token from AWS SSM Parameter Store instead of taking it in as a Command parameter (avoid leaks in the AWS Console)
+TOKEN="{{ Token }}"
+TAGS="{{ Tags }}"
+
+
+# TODO: Handle systems that don't have systemctl
+if systemctl is-active --quiet kubelet; then
+  echo "This host appears to be a Kubernetes node, please use the Kubernetes deployment method (https://support.lacework.com/hc/en-us/articles/360005263034-Deploy-on-Kubernetes)."
+  exit 0
+fi
+
+if [ ! -d "$LACEWORK_INSTALL_PATH" ]; then
+  echo "Lacework agent not installed, installing..."
+
+  # TODO: Add the support for hosts that don't have curl installed
+  curl https://packages.lacework.net/install.sh > /tmp/install.sh
+
+  chmod +x /tmp/install.sh
+
+  # TODO: Pass tags to the installation script
+  sudo /tmp/install.sh "$TOKEN"
+
+  rm /tmp/install.sh
+else
+  echo "Lacework is already installed, configuring the agent token..."
+
+  # TODO: Add the support for other Lacework configuration options
+  cat > "$LACEWORK_INSTALL_PATH/config/config.json" <<EOF
+{
+  "tokens": {
+    "AccessToken": "$TOKEN"
+  },
+  "tags": $TAGS
+}
+EOF
+fi
+
+echo "Lacework configured successfully!"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,22 @@
+variable "lacework_access_token" {
+  type        = string
+  description = "The access token for the Lacework agent"
+}
+
+variable "lacework_agent_tags" {
+  type        = map(string)
+  description = "A map/dictionary of Tags to be assigned to the Lacework datacollector"
+  default     = {}
+}
+
+variable "aws_resources_prefix" {
+  type        = string
+  description = "Prefix to use for created AWS resources"
+  default     = ""
+}
+
+variable "aws_resources_tags" {
+  type        = map(string)
+  description = "A map/dictionary of Tags to be assigned to created AWS resources"
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "lacework_access_token" {
   type        = string
   description = "The access token for the Lacework agent"
+  default     = ""
 }
 
 variable "lacework_agent_tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.0"
+}


### PR DESCRIPTION
This is the naive implementation that assumes many things about targeted hosts. Multiple TODOs were added to guide future improvements.

Signed-off-by: Jean-Philippe Lachance <jplachance@coveo.com>