### PR TITLE
docs: add example that use the our Terraform Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A Terraform Module to create an AWS Systems Manager document for installing the 
 
 ## Inputs
 
-| Name | Description | Type | Default |
-|------|-------------|------|---------|
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
 | lacework_agent_tags | A map/dictionary of Tags to be assigned to the Lacework datacollector | `map(string)` | `{}` | no |
 | aws_resources_tags | A map/dictionary of Tags to be assigned to created AWS resources | `map(string)` | `{}` | no |
 | aws_resources_prefix | Prefix to use for created AWS resources | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # terraform-aws-ssm-agent
 
+[![GitHub release](https://img.shields.io/github/release/lacework/terraform-aws-ssm-agent.svg)](https://github.com/lacework/terraform-aws-ssm-agent/releases/)
+[![CircleCI status](https://circleci.com/gh/lacework/terraform-aws-ssm-agent.svg?style=shield)](https://circleci.com/gh/lacework/terraform-aws-ssm-agent)
+
 A Terraform Module to create an AWS Systems Manager document for installing the Lacework Datacollector Agent on to AWS EC2 instances.
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 # terraform-aws-ssm-agent
 
-## Description
-
 A Terraform Module to create an AWS Systems Manager document for installing the Lacework Datacollector Agent on to AWS EC2 instances.
 
 ## Inputs
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-
+| lacework_agent_tags | A map/dictionary of Tags to be assigned to the Lacework datacollector | `map(string)` | `{}` | no |
+| aws_resources_tags | A map/dictionary of Tags to be assigned to created AWS resources | `map(string)` | `{}` | no |
+| aws_resources_prefix | Prefix to use for created AWS resources | `string` | `""` | no |
+| lacework_access_token | The access token for the Lacework agent | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| ssm_document_name | Name of the AWS SSM Document that setups the Lacework agent |

--- a/examples/access-lacework-token-via-provider/README.md
+++ b/examples/access-lacework-token-via-provider/README.md
@@ -1,0 +1,5 @@
+# AWS SSM Command using Lacework Provider
+
+This example shows how to use the Terraform Provider for Lacework to create
+a new Lacework Agent Token and use it to deploy an AWS System Manager Command
+that can be used to install the Lacework Agent on a Linux EC2 instance.

--- a/examples/access-lacework-token-via-provider/main.tf
+++ b/examples/access-lacework-token-via-provider/main.tf
@@ -1,0 +1,68 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "lacework_aws_ssm_agents_install" {
+  source = "../../"
+
+  lacework_agent_tags = {
+    env = "dev"
+  }
+
+  aws_resources_tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}
+
+resource "aws_resourcegroups_group" "testing" {
+  name = "Testing"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = [
+        "AWS::EC2::Instance"
+      ]
+
+      TagFilters = [
+        {
+          Key = "environment"
+          Values = [
+            "Testing"
+          ]
+        }
+      ]
+    })
+  }
+
+  tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}
+
+provider "lacework" {}
+
+resource "lacework_agent_access_token" "ssm_deployment" {
+  name        = "ssm-deployment"
+  description = "Used to deploy agents using AWS System Manager"
+}
+
+resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
+  association_name = "install-lacework-agents-testing-group"
+
+  name = module.lacework_aws_ssm_agents_install.ssm_document_name
+
+  targets {
+    key = "resource-groups:Name"
+    values = [
+      aws_resourcegroups_group.testing.name,
+    ]
+  }
+
+  parameters = {
+    Token = lacework_agent_access_token.ssm_deployment.token
+  }
+
+  compliance_severity = "HIGH"
+}

--- a/examples/access-lacework-token-via-provider/main.tf
+++ b/examples/access-lacework-token-via-provider/main.tf
@@ -2,6 +2,13 @@ provider "aws" {
   region = "us-east-1"
 }
 
+provider "lacework" {}
+
+resource "lacework_agent_access_token" "ssm_deployment" {
+  name        = "ssm-deployment"
+  description = "Used to deploy agents using AWS System Manager"
+}
+
 module "lacework_aws_ssm_agents_install" {
   source = "../../"
 
@@ -13,6 +20,8 @@ module "lacework_aws_ssm_agents_install" {
     billing = "testing"
     owner   = "myself"
   }
+
+  lacework_access_token = lacework_agent_access_token.ssm_deployment.token
 }
 
 resource "aws_resourcegroups_group" "testing" {
@@ -41,13 +50,6 @@ resource "aws_resourcegroups_group" "testing" {
   }
 }
 
-provider "lacework" {}
-
-resource "lacework_agent_access_token" "ssm_deployment" {
-  name        = "ssm-deployment"
-  description = "Used to deploy agents using AWS System Manager"
-}
-
 resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
   association_name = "install-lacework-agents-testing-group"
 
@@ -58,10 +60,6 @@ resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
     values = [
       aws_resourcegroups_group.testing.name,
     ]
-  }
-
-  parameters = {
-    Token = lacework_agent_access_token.ssm_deployment.token
   }
 
   compliance_severity = "HIGH"

--- a/examples/access-lacework-token-via-provider/versions.tf
+++ b/examples/access-lacework-token-via-provider/versions.tf
@@ -3,5 +3,9 @@ terraform {
 
   required_providers {
     aws = "~> 3.0"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.2.13"
+    }
   }
 }

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -1,3 +1,7 @@
 terraform {
   required_version = ">= 0.12.0"
+
+  required_providers {
+    aws = "~> 3.0"
+  }
 }

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -10,6 +10,7 @@ readonly project_name=terraform-aws-ssm-agent
 
 TEST_CASES=(
   examples/default
+  examples/access-lacework-token-via-provider
 )
 
 log() {


### PR DESCRIPTION
# AWS SSM Command using Lacework Provider

This example shows how to use the Terraform Provider for Lacework to create
a new Lacework Agent Token and use it to deploy an AWS System Manager Command
that can be used to install the Lacework Agent on a Linux EC2 instance.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>