### PR TITLE
fix(command): Fix a typo in the Command Tags parameter description

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,9 @@ resource "aws_ssm_document" "setup_lacework_agent" {
         default     = var.lacework_access_token
       }
 
-      # TODO: Figure out the proper way of passing tags to our bash script, currently does not generate a valid config.json file
       Tags = {
         type        = "String"
-        description = "The Lacework agent token"
+        description = "The Lacework agent tags"
         default     = jsonencode(var.lacework_agent_tags)
       }
     }


### PR DESCRIPTION
And remove a TODO we addressed in a previous PR.

Signed-off-by: Jean-Philippe Lachance <jplachance@coveo.com>