### PR TITLE
feat: ability to specify an Agent build hash

### DIFF
--- a/examples/custom-agent-build-hash/main.tf
+++ b/examples/custom-agent-build-hash/main.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_ssm_agents_install_custom_agent_build_hash" {
+  source = "../../"
+
+  lacework_agent_tags = {
+    env = "dev"
+  }
+
+  lacewwork_agent_build_hash = "3.7.2_2021-03-26_branch_123HASH"
+}
+
+resource "aws_resourcegroups_group" "testing" {
+  name = "Testing"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = [
+        "AWS::EC2::Instance"
+      ]
+
+      TagFilters = [
+        {
+          Key = "environment"
+          Values = [
+            "Testing"
+          ]
+        }
+      ]
+    })
+  }
+
+  tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}
+
+resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
+  association_name = "install-lacework-agents-testing-group"
+
+  name = module.lacework_aws_ssm_agents_install.ssm_document_name
+
+  targets {
+    key = "resource-groups:Name"
+    values = [
+      aws_resourcegroups_group.testing.name,
+    ]
+  }
+
+  parameters = {
+    Token = "my-lacework-token"
+  }
+
+  compliance_severity = "HIGH"
+}

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,12 @@ resource "aws_ssm_document" "setup_lacework_agent" {
         description = "The Lacework agent tags"
         default     = jsonencode(var.lacework_agent_tags)
       }
+
+      Hash = {
+        type        = "String"
+        description = "An Agent build hash provided by Lacework"
+        default     = var.lacework_agent_build_hash
+      }
     }
 
     mainSteps = [

--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -7,6 +7,7 @@ LACEWORK_INSTALL_PATH="{{ LaceworkInstallPath }}"
 # TODO: Fetch the token from AWS SSM Parameter Store instead of taking it in as a Command parameter (avoid leaks in the AWS Console)
 TOKEN='{{ Token }}'
 TAGS='{{ Tags }}'
+BUILD_HASH='{{ Hash }}'
 
 command_exists() {
   command -v "$@" >/dev/null 2>&1
@@ -48,8 +49,13 @@ fi
 if [ ! -f "$LACEWORK_INSTALL_PATH/datacollector" ]; then
   echo "Lacework agent not installed, installing..."
 
+  _install_sh="https://packages.lacework.net/install.sh"
+  if [ $BUILD_HASH != "" ]; then
+    _install_sh="https://s3-us-west-2.amazonaws.com/www.lacework.net/download/${BUILD_HASH}/install.sh"
+  fi
+
   # TODO: Verify the signature of the install.sh script
-  $curl https://packages.lacework.net/install.sh >/tmp/install.sh
+  $curl "$_install_sh" >/tmp/install.sh
 
   chmod +x /tmp/install.sh
 

--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -50,7 +50,7 @@ if [ ! -f "$LACEWORK_INSTALL_PATH/datacollector" ]; then
   echo "Lacework agent not installed, installing..."
 
   _install_sh="https://packages.lacework.net/install.sh"
-  if [ $BUILD_HASH != "" ]; then
+  if [ "$BUILD_HASH" != "" ]; then
     _install_sh="https://s3-us-west-2.amazonaws.com/www.lacework.net/download/${BUILD_HASH}/install.sh"
   fi
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "lacework_agent_build_hash" {
+  type        = string
+  description = "An Agent build hash provided by Lacework"
+  default     = ""
+}
+
 variable "lacework_access_token" {
   type        = string
   description = "The access token for the Lacework agent"


### PR DESCRIPTION
## User Story
As a Lacework user that wants to deploy early changes to our Agent/install.sh script,
I need to have a way to point to different versions of the Agent/install.sh script,
So I am now locked up to Lacework's 3-month release process to the Agent/install.sh script located at https://packages.lacework.net/install.sh

## Proposal Solution

We are going to implement a mechanism for the user to provide a specific `BUILD_GIT_HASH` so that our CS teams can provide it to our customers and ultimately, our users can use a different version of the Agent/install.sh.

Example:
```hcl
provider "aws" {}

provider "lacework" {}

module "ssm-agent" {
  source  = "lacework/ssm-agent/aws"
  version = "~> 0.3"

  lacework_agent_build_hash = "3.7.2_2021-03-26_branch_123HASH"
  lacework_agent_tags = {
    env = "dev"
  }
}
```

Closes Jira ALLY-455

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>