### PR TITLE
fix: deployment of Agent config.json file

### DIFF
--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -57,7 +57,7 @@ render_agent_config() {
   fi
 
   # Tags
-  _tags_json='"tags": '${TAGS:-{}}
+  _tags_json='"tags": '${TAGS:-"{}"}
 
   # Render config.json
   #
@@ -66,7 +66,7 @@ render_agent_config() {
   #       a valid JSON
   _config_json="""{
   ${_token_json}
-  ${_server_url_json:-\033[A}
+  ${_server_url_json}
   ${_tags_json}
 }"""
 


### PR DESCRIPTION
Closes https://github.com/lacework/terraform-aws-ssm-agent/issues/21

JIRA: https://lacework.atlassian.net/browse/ALLY-503

This fix will render a valid JSON:
```
[ec2-user@ip-172-31-25-223 ~]$ render_agent_config
Updating the Lacework agent config.json file...
{
  "tokens": { "AccessToken": "foo" },

  "tags": {"env":"dev"}
}
```

Not pretty, but valid!

![tenor-213816803](https://user-images.githubusercontent.com/5712253/119178161-91a78600-ba2a-11eb-950f-a561e85d8e60.gif)

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>