### PR TITLE
feat: adding ability to customize temporary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ A Terraform Module to create an AWS Systems Manager document for installing the 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-| lacework_agent_tags | A map/dictionary of Tags to be assigned to the Lacework datacollector | `map(string)` | `{}` | no |
-| aws_resources_tags | A map/dictionary of Tags to be assigned to created AWS resources | `map(string)` | `{}` | no |
+|------|-------------|------|---------|:--------:|
 | aws_resources_prefix | Prefix to use for created AWS resources | `string` | `""` | no |
+| aws_resources_tags | A map/dictionary of Tags to be assigned to created AWS resources | `map(string)` | `{}` | no |
 | lacework_access_token | The access token for the Lacework agent | `string` | `""` | no |
+| lacework_agent_build_hash | An Agent build hash provided by Lacework | `string` | `""` | no |
+| lacework_agent_tags | A map/dictionary of Tags to be assigned to the Lacework datacollector | `map(string)` | `{}` | no |
+| lacework_agent_temp_path | The temporary path for the Lacework installation script | `string` | `"/tmp"` | no |
 | lacework_server_url | The server URL for the Lacework agent | `string` | `""` | no |
 
 ## Outputs

--- a/examples/custom-agent-temp-path/README.md
+++ b/examples/custom-agent-temp-path/README.md
@@ -1,0 +1,17 @@
+# AWS SSM Command using a Custom Temporary Path
+
+This example shows how to customize the Lacework Agent installation to use a
+explcitly defined temporary path for downloading the installation script - rather than `/tmp`.
+
+```hcl
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_ssm_agents_install_custom_agent_build_hash" {
+  source  = "lacework/ssm-agent/aws"
+  version = "~> 0.4"
+
+  lacework_agent_temp_path = "/new/temp/path"
+}
+```

--- a/examples/custom-agent-temp-path/main.tf
+++ b/examples/custom-agent-temp-path/main.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_ssm_agents_install_custom_agent_build_hash" {
+  source = "../../"
+
+  lacework_agent_temp_path = "/new/temp/path"
+}
+
+resource "aws_resourcegroups_group" "testing" {
+  name = "Testing"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = [
+        "AWS::EC2::Instance"
+      ]
+
+      TagFilters = [
+        {
+          Key = "environment"
+          Values = [
+            "Testing"
+          ]
+        }
+      ]
+    })
+  }
+
+  tags = {
+    billing = "testing"
+    owner   = "myself"
+  }
+}
+
+resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
+  association_name = "install-lacework-agents-testing-group"
+
+  name = module.lacework_ssm_agents_install_custom_agent_build_hash.ssm_document_name
+
+  targets {
+    key = "resource-groups:Name"
+    values = [
+      aws_resourcegroups_group.testing.name,
+    ]
+  }
+
+  parameters = {
+    Token = "my-lacework-token"
+  }
+
+  compliance_severity = "HIGH"
+}

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,12 @@ resource "aws_ssm_document" "setup_lacework_agent" {
         default     = "/var/lib/lacework"
       }
 
+      LaceworkTempPath = {
+        type        = "String"
+        description = "The temporary path for the Lacework installation script"
+        default     = var.lacework_agent_temp_path
+      }
+
       Token = {
         type        = "String"
         description = "The access token for the Lacework agent"

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -12,6 +12,7 @@ TEST_CASES=(
   examples/default
   examples/access-lacework-token-via-provider
   examples/custom-agent-build-hash
+  examples/custom-agent-temp-path
   examples/custom-server-url
 )
 

--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -4,6 +4,7 @@ set -e
 
 # Variables coming from the SSM Document
 LACEWORK_INSTALL_PATH='{{ LaceworkInstallPath }}'
+LACEWORK_TEMP_PATH='{{ LaceworkTempPath }}'
 TAGS='{{ Tags }}'
 BUILD_HASH='{{ Hash }}'
 SERVER_URL='{{ Serverurl }}'
@@ -89,13 +90,13 @@ install_lacework_agent() {
     fi
 
     # TODO: Verify the signature of the install.sh script
-    $_curl "$_install_sh" >/tmp/install.sh
+    $_curl "$_install_sh" >"$LACEWORK_TEMP_PATH/install.sh"
 
-    chmod +x /tmp/install.sh
+    chmod +x "$LACEWORK_TEMP_PATH/install.sh"
 
-    sudo /tmp/install.sh "$TOKEN"
+    sudo "$LACEWORK_TEMP_PATH/install.sh" "$TOKEN"
 
-    rm /tmp/install.sh
+    rm "$LACEWORK_TEMP_PATH/install.sh"
   fi
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "lacework_agent_tags" {
   default     = {}
 }
 
+variable "lacework_agent_temp_path" {
+  type        = string
+  description = "The temporary path for the Lacework installation script"
+  default     = "/tmp"
+}
+
 variable "aws_resources_prefix" {
   type        = string
   description = "Prefix to use for created AWS resources"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Allow users to customize the temporary path used to download the Lacework agent installation script via Terraform variable.
This will allow for users to change the path where the install script is downloaded to a different directory if they've hardened their Linux host(s) according to the following: https://www.stigviewer.com/stig/red_hat_enterprise_linux_6/2016-12-16/finding/V-57569

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I simply did a check of the `make ci` output, so we need to make sure this is tested with a genuine deployment.