### PR TITLE
fix: update installation URL for custom build hashes

### DIFF
--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -86,7 +86,7 @@ install_lacework_agent() {
 
     _install_sh="https://packages.lacework.net/install.sh"
     if [ "$BUILD_HASH" != "" ]; then
-      _install_sh="https://s3-us-west-2.amazonaws.com/www.lacework.net/download/${BUILD_HASH}/install.sh"
+      _install_sh="https://updates.lacework.net/${BUILD_HASH}/install.sh"
     fi
 
     # TODO: Verify the signature of the install.sh script


### PR DESCRIPTION
## Summary

We changed the installation URL from an S3 bucket to our own hosted artifact location. The user
needs to specify the build hash still, which is provided by contacting support which ultimately will
reach out to our Agent/PM team to get the latest Agent version.

## How did you test this change?

There is a test and I will need someone to help me test end-to-end.

**UPDATE** Daniel Fitzgerald helped test this change
 
![Screen Shot 2022-08-31 at 9 50 09 AM](https://user-images.githubusercontent.com/5712253/187735085-c658b23b-ac85-4d45-abbe-b066c6d3964d.png)

## Issue

https://lacework.atlassian.net/browse/ALLY-1172
