### PR TITLE
chore: update Lacework provider version

### DIFF
--- a/examples/access-lacework-token-via-provider/versions.tf
+++ b/examples/access-lacework-token-via-provider/versions.tf
@@ -1,11 +1,11 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = "~> 3.0"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/custom-server-url/versions.tf
+++ b/examples/custom-server-url/versions.tf
@@ -1,11 +1,11 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = "~> 1.0"
 
   required_providers {
     aws = "~> 3.0"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.4"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0

[_Created by Sourcegraph batch change `darren.murray/terraform-provider-updater`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-provider-updater)