### PR TITLE
fix: pass server url to agent install.sh

### DIFF
--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -94,7 +94,13 @@ install_lacework_agent() {
 
     chmod +x "$LACEWORK_TEMP_PATH/install.sh"
 
-    sudo "$LACEWORK_TEMP_PATH/install.sh" "$TOKEN"
+    # Pass flag '-U' when a server URL is provided
+    local _flags
+    if [ "$SERVER_URL" != "" ]; then
+      _flags="-U $SERVER_URL"
+    fi
+
+    sudo "$LACEWORK_TEMP_PATH/install.sh" "$TOKEN" $_flags
 
     rm "$LACEWORK_TEMP_PATH/install.sh"
   fi


### PR DESCRIPTION

## Summary

When executing the `install.sh` that we download from https://packages.lacework.net/install.sh and
execute it, the installer has the server url https://api.lacework.net/  hardcoded.

We are now passing the flag `-U serverUrl` during the agent installation.

## How did you test this change?

Installed an agent via SSM Manager.

## Issue

https://lacework.atlassian.net/browse/GROW-1481
