### PR TITLE
fix(CPLAT-672): Update references to api.lacework.net

### DIFF
--- a/examples/custom-server-url/README.md
+++ b/examples/custom-server-url/README.md
@@ -12,6 +12,6 @@ module "lacework_ssm_agents_install_custom_server_url" {
   source  = "lacework/ssm-agent/aws"
   version = "~> 0.4"
 
-  lacework_server_url   = "https://api.lacework.net"
+  lacework_server_url   = "https://agent.lacework.net"
 }
 ```

--- a/examples/custom-server-url/main.tf
+++ b/examples/custom-server-url/main.tf
@@ -13,7 +13,7 @@ module "lacework_ssm_agents_install_custom_server_url" {
   source = "../../"
 
   lacework_access_token = lacework_agent_access_token.ssm_deployment.token
-  lacework_server_url   = "https://api.lacework.net"
+  lacework_server_url   = "https://agent.lacework.net"
 }
 
 resource "aws_resourcegroups_group" "testing" {


### PR DESCRIPTION
## Summary
Refer [CPLAT-672](https://lacework.atlassian.net/browse/CPLAT-672)
We are moving to new dns naming conventions api.lacework.net => agent.lacework.net

## How did you test this change?

Manually - RAIN-59923, RAIN-59923

## Issue

[CPLAT-672](https://lacework.atlassian.net/browse/CPLAT-672)

[CPLAT-672]: https://lacework.atlassian.net/browse/CPLAT-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPLAT-672]: https://lacework.atlassian.net/browse/CPLAT-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ