### PR TITLE
feat: add flag to add syscall default config

### DIFF
--- a/examples/enable-syscall-default-config/README.md
+++ b/examples/enable-syscall-default-config/README.md
@@ -1,0 +1,17 @@
+# AWS SSM Command with Syscall Default Config Enabled
+
+This example shows how to enable the syscall default config in
+the agent.
+
+```hcl
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lacework_aws_ssm_agents_install_enable_syscall_default_config" {
+  source  = "lacework/ssm-agent/aws"
+  version = "~> 0.4"
+
+  lacework_enable_default_syscall_config = true
+}
+```

--- a/examples/enable-syscall-default-config/main.tf
+++ b/examples/enable-syscall-default-config/main.tf
@@ -1,0 +1,43 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "lacework" {}
+
+resource "lacework_agent_access_token" "ssm_deployment" {
+  name        = "ssm-deployment"
+  description = "Used to deploy agents using AWS System Manager"
+}
+
+module "lacework_ssm_agents_install_enable_syscall_default_config" {
+  source = "../../"
+
+  lacework_access_token = lacework_agent_access_token.ssm_deployment.token
+  lacework_server_url   = "https://agent.lacework.net"
+  lacework_enable_default_syscall_config = true
+}
+
+resource "aws_resourcegroups_group" "testing" {
+  name = "Testing"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = [
+        "AWS::EC2::Instance"
+      ]
+    })
+  }
+}
+
+resource "aws_ssm_association" "lacework_aws_ssm_agents_install_testing" {
+  association_name = "install-lacework-agents-testing-group"
+
+  name = module.lacework_ssm_agents_install_enable_syscall_default_config.ssm_document_name
+
+  targets {
+    key = "resource-groups:Name"
+    values = [
+      aws_resourcegroups_group.testing.name,
+    ]
+  }
+}

--- a/examples/enable-syscall-default-config/versions.tf
+++ b/examples/enable-syscall-default-config/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.12.31"
+
+  required_providers {
+    aws = "~> 3.0"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.4"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,12 @@ resource "aws_ssm_document" "setup_lacework_agent" {
         description = "An Agent build hash provided by Lacework"
         default     = var.lacework_agent_build_hash
       }
+
+      EnableDefaultSyscallConfig = {
+        type        = "Boolean"
+        description = "A flag to enable the default syscall config"
+        default     = var.lacework_enable_default_syscall_config
+      }
     }
 
     mainSteps = [

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -14,6 +14,7 @@ TEST_CASES=(
   examples/custom-agent-build-hash
   examples/custom-agent-temp-path
   examples/custom-server-url
+  examples/enable-syscall-default-config
 )
 
 log() {

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,9 @@ variable "lacework_server_url" {
   default     = ""
   description = "The server URL for the Lacework agent"
 }
+
+variable "lacework_enable_default_syscall_config" {
+  type        = bool
+  default     = false
+  description = "A flag to enable the default syscall config"
+}


### PR DESCRIPTION
This commit adds a new variable to the Terraform specification called
`lacework_enable_default_syscall_config`. When this variable is set to
`true`, the install will create a new file at
`/var/lib/lacework/config/syscall_config.yaml` which the agent will
automatically read. This file contains the recommended syscall
configuration. The default for this new variable is `false` as syscall
configuration is currently in private preview.

Resolves RAIN-59161

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## How did you test this change?

Ran `setup_lacework_agent.sh` locally and confirmed that `/var/lib/lacework/config/syscall_config.yaml` contained the correct output. Ran it again with the flag hardcoded to false and confirmed that it didn't add the syscall config file. 

Also added a new example with this functionality that will run in CI

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-59161
