### PR TITLE
fix: add new syscall enable flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A Terraform Module to create an AWS Systems Manager document for installing the 
 | lacework_agent_tags | A map/dictionary of Tags to be assigned to the Lacework datacollector | `map(string)` | `{}` | no |
 | lacework_agent_temp_path | The temporary path for the Lacework installation script | `string` | `"/tmp"` | no |
 | lacework_server_url | The server URL for the Lacework agent | `string` | `""` | no |
+| lacework_enable_default_syscall_config | A flag to enable the default syscall config | `bool` | `false` | no |
 
 ## Outputs
 


### PR DESCRIPTION
This was missed in
d65fb2f9baa7d7f99399526f211bb589d64d5e16

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This will render the new flag in https://registry.terraform.io/modules/lacework/ssm-agent/aws/latest. Thanks @selvats for spotting this!
