### PR TITLE
fix: update incorrect variable name

### DIFF
--- a/setup_lacework_agent.sh
+++ b/setup_lacework_agent.sh
@@ -11,7 +11,7 @@ SERVER_URL='{{ Serverurl }}'
 # TODO: Fetch the token from AWS SSM Parameter Store instead of
 #       taking it in as a Command parameter (avoid leaks in the AWS Console)
 TOKEN='{{ Token }}'
-ENABLE_DEFAULT_SYSCALL_CONFIG='{{ EnableSyscallDefaultConfig }}'
+ENABLE_DEFAULT_SYSCALL_CONFIG='{{ EnableDefaultSyscallConfig }}'
 
 # Global variables
 _curl=''


### PR DESCRIPTION
`setup_lacework_agent.sh` has a typo in reading the Terraform variable name for enabling syscall default config. This commit fixes it.

Resolves LINK-1965

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/LINK-1965
