### PR TITLE
fix: use correct type for enable syscall var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_ssm_document" "setup_lacework_agent" {
       }
 
       EnableDefaultSyscallConfig = {
-        type        = "Boolean"
+        type        = "String"
         description = "A flag to enable the default syscall config"
         default     = var.lacework_enable_default_syscall_config
       }


### PR DESCRIPTION
Resolves LINK-1965

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Customer getting this error:

```console
│ Error: creating SSM Document (setup-lacework-agent): InvalidDocumentContent: Wrong default value for a "Boolean" parameters, got "false". at Line: 1, Column: 6081
│   with module.lacework_aws_ssm_agents_install.aws_ssm_document.setup_lacework_agent,
│   on .terraform/modules/lacework_aws_ssm_agents_install/main.tf line 1, in resource "aws_ssm_document" "setup_lacework_agent":
│    1: resource "aws_ssm_document" "setup_lacework_agent" {
```

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
I ran `terraform apply`, reproduced the error, then made this fix, tested again and it worked. It would be great to have an actual AWS backend in the CI pipeline

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/LINK-1965
