### PR TITLE
fix: default additionalconfig to empty string when not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "aws_ssm_document" "setup_lacework_agent" {
       AdditionalConfig = {
         type        = "String"
         description = "Additional configuration parameters for the Lacework agent"
-        default     = jsonencode(var.lacework_agent_configuration)
+        default     = length(var.lacework_agent_configuration) == 0 ? "" : jsonencode(var.lacework_agent_configuration)
       }
     }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ssm-agent/blob/main/CONTRIBUTING.md
--->

## Summary

When variable lacework_agent_configuration is not set default AdditionalConfig to empty string

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- [x] Terraform Apply, verify config.json is correct
